### PR TITLE
Add bootstrap script and docs for Telegram quickstart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Shared Secrets
+TG_SHARED_TOKEN=super-secret-token
+
 # Telegram Bot
 TG_TRADER_BOT_TELEGRAM_TOKEN=your-telegram-token
 TG_TRADER_BOT_API_BASE_URL=http://localhost:8080
@@ -8,6 +11,7 @@ TG_TRADER_API_REDIS_URL=redis:6379
 TG_TRADER_API_API_TOKEN=super-secret-token
 TG_TRADER_API_RATE_LIMIT_RPS=10
 TG_TRADER_API_TA_SERVICE_URL=http://ta-service:9100
+TG_TRADER_API_ALLOWED_CHATS=
 
 # Exec Service
 TG_TRADER_EXEC__REDIS_URL=redis://redis:6379

--- a/README.md
+++ b/README.md
@@ -14,23 +14,46 @@ A production-ready monorepo for a latency-optimized Telegram crypto trading bot.
 - Technical analysis service (Go + Rust FFI) maintaining Binance/Uniswap candles, computing RSI/MACD/Bollinger/ATR, and exposing REST/WebSocket feeds plus CSV-driven backtesting CLI
 
 ## Quickstart
-1. Copy `.env.example` to `.env` and populate secrets
-2. Start local dependencies:
-   ```bash
-   cd ops
-   make up
-   ```
-3. Run migrations (requires psql access):
-   ```bash
-   psql postgresql://trader:password@localhost:5432/trader -f ../data/migrations/0001_init.sql
-   ```
-4. Launch exec in dry-run mode (optional outside Docker):
-   ```bash
-   cargo run -p exec
-   ```
-5. Connect Telegram bot to your chat and issue `/buy ETHUSDT 0.01 0.5%`
-6. Explore TA commands such as `/signals ETHUSDT 1m` and enable filters `/autotrade on rsi<30 1m`
-6. Inspect Redis stream `trade-intents` and exec logs for lifecycle; revoke approvals via surfaced link post-trade
+
+### Prerequisites
+- Docker + Docker Compose
+- GNU Make
+- A Telegram account (to create a bot with [@BotFather](https://t.me/BotFather))
+
+### 1. Configure secrets interactively
+Run the bootstrap helper and follow the prompts for your Telegram token, shared API secret, and allowed chat IDs:
+
+```bash
+./scripts/bootstrap.sh
+```
+
+The script copies `.env.example`, keeps the generated API tokens in sync across services (including `docker-compose`), and stores your chat allowlist.
+
+### 2. Launch the Docker stack
+Bring up Redis, Postgres, TA service, API, exec engine, and the Telegram bot in the background. Leave this terminal open; the
+next commands assume you remain inside `ops/`:
+
+```bash
+cd ops
+make up
+```
+
+### 3. Apply the database schema
+After the containers report healthy status, load the default schema from inside `ops/` (run once):
+
+```bash
+make migrate
+```
+
+### 4. Talk to your Telegram bot
+Search for your bot in Telegram, press **/start**, and try commands such as:
+
+```
+/buy ETHUSDT 0.01 0.5%
+/signals ETHUSDT 1m
+```
+
+Use `make down` (inside `ops/`) to stop the stack, or rerun `./scripts/bootstrap.sh` anytime you need to update secrets.
 
 ## Testing
 - Go services: `go test ./...`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@ http_addr: ":8080"
 metrics_addr: ":9100"
 redis_url: "redis:6379"
 api_token: "${TG_SHARED_TOKEN}"
+allowed_chats: []
 rate_limit_rps: 10
 ta_service_url: "http://ta-service:9100"
 ```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -12,6 +12,7 @@
 - Build images via `make build` in `ops/`
 - Deploy stack using docker-compose or Kubernetes manifests (todo)
 - Provide `.env` with Telegram token, API token, Redis URL.
+- After first launch run `make migrate` in `ops/` to seed the Postgres schema.
 
 ## Backups
 - Postgres/Timescale retains trade history; run daily dumps via `pg_dump`.

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,16 +1,19 @@
-.PHONY: build up down lint fmt test
+.PHONY: build up down lint fmt test migrate
 
 build:
 docker compose -f docker-compose.yml build
 
 up:
-docker compose -f docker-compose.yml up -d
+    docker compose -f docker-compose.yml up -d
 
 up-dev:
 TG_TRADER_BOT_TELEGRAM_TOKEN=$${TG_TRADER_BOT_TELEGRAM_TOKEN} TG_SHARED_TOKEN=local-token docker compose -f docker-compose.yml up --build
 
 down:
-docker compose -f docker-compose.yml down -v
+    docker compose -f docker-compose.yml down -v
+
+migrate:
+    docker compose -f docker-compose.yml exec -T postgres psql -U trader -d trader < ../data/migrations/0001_init.sql
 
 fmt:
 cargo fmt --all

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_EXAMPLE="$ROOT_DIR/.env.example"
+ENV_FILE="$ROOT_DIR/.env"
+
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+  echo "[bootstrap] .env.example is missing. Please pull the repo again." >&2
+  exit 1
+fi
+
+ENV_CREATED=false
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  cp "$ENV_EXAMPLE" "$ENV_FILE"
+  ENV_CREATED=true
+  echo "[bootstrap] Created .env from template."
+else
+  echo "[bootstrap] Using existing .env (values will be updated in-place)."
+fi
+
+prompt() {
+  local var_name="$1"
+  local prompt_text="$2"
+  local default_value="${3-}"
+
+  local existing_value=""
+  if [[ "$ENV_CREATED" == false ]]; then
+    existing_value="$(grep -E "^${var_name}=" "$ENV_FILE" | head -n1 | cut -d'=' -f2-)"
+  fi
+  if [[ -z "$existing_value" && -n "$default_value" ]]; then
+    existing_value="$default_value"
+  fi
+
+  if [[ -n "$existing_value" ]]; then
+    read -rp "$prompt_text [$existing_value]: " input_value
+    if [[ -z "$input_value" ]]; then
+      input_value="$existing_value"
+    fi
+  else
+    while true; do
+      read -rp "$prompt_text: " input_value
+      if [[ -n "$input_value" ]]; then
+        break
+      fi
+      echo "Please provide a value." >&2
+    done
+  fi
+
+  printf '%s' "$input_value"
+}
+
+update_env_var() {
+  local key="$1"
+  local value="$2"
+
+  python3 - "$ENV_FILE" "$key" "$value" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+
+lines = path.read_text().splitlines() if path.exists() else []
+pattern = re.compile(rf"^{re.escape(key)}=")
+for idx, line in enumerate(lines):
+    if pattern.match(line):
+        lines[idx] = f"{key}={value}"
+        break
+else:
+    lines.append(f"{key}={value}")
+path.write_text("\n".join(lines) + "\n")
+PY
+}
+
+generate_secret() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+  else
+    python3 - <<'PY'
+import secrets
+print(secrets.token_hex(16))
+PY
+  fi
+}
+
+cat <<'MSG'
+============================
+Telegram Bot Bootstrap Wizard
+============================
+This script will prepare environment variables and explain how to start the stack.
+Press enter to accept defaults from .env.example.
+MSG
+
+TELEGRAM_TOKEN=$(prompt "TG_TRADER_BOT_TELEGRAM_TOKEN" "Enter your Telegram bot token (from @BotFather)")
+update_env_var "TG_TRADER_BOT_TELEGRAM_TOKEN" "$TELEGRAM_TOKEN"
+
+API_TOKEN_DEFAULT=$(generate_secret)
+API_TOKEN=$(prompt "TG_TRADER_BOT_API_TOKEN" "Shared API token used between services" "$API_TOKEN_DEFAULT")
+update_env_var "TG_TRADER_BOT_API_TOKEN" "$API_TOKEN"
+update_env_var "TG_TRADER_API_API_TOKEN" "$API_TOKEN"
+update_env_var "TG_SHARED_TOKEN" "$API_TOKEN"
+
+CHAT_IDS=$(prompt "TG_TRADER_API_ALLOWED_CHATS" "Comma separated Telegram chat IDs allowed to trade (from @userinfobot)" "")
+if [[ -n "$CHAT_IDS" ]]; then
+  update_env_var "TG_TRADER_API_ALLOWED_CHATS" "$CHAT_IDS"
+fi
+
+API_BASE_URL=$(prompt "TG_TRADER_BOT_API_BASE_URL" "Bot API base URL" "http://localhost:8080")
+update_env_var "TG_TRADER_BOT_API_BASE_URL" "$API_BASE_URL"
+
+REDIS_URL=$(prompt "TG_TRADER_API_REDIS_URL" "Redis connection string" "redis:6379")
+update_env_var "TG_TRADER_API_REDIS_URL" "$REDIS_URL"
+if [[ "$REDIS_URL" == redis://* ]]; then
+  EXEC_REDIS_URL="$REDIS_URL"
+else
+  EXEC_REDIS_URL="redis://$REDIS_URL"
+fi
+update_env_var "TG_TRADER_EXEC__REDIS_URL" "$EXEC_REDIS_URL"
+
+cat <<'NEXT'
+
+Next steps:
+1. If you skipped the chat ID prompt, message @userinfobot and append the numeric "Id" to TG_TRADER_API_ALLOWED_CHATS in your .env file.
+2. Start the stack with Docker Compose:
+     cd ops
+     make up
+3. Run the database migration once (after the containers are healthy):
+     cd ops
+     make migrate
+4. Open Telegram, search for your bot, press /start, and run /buy or /signals commands.
+
+To tear down the stack run `make down` from the same directory.
+NEXT
+
+printf '\n[bootstrap] Environment is ready.\n'


### PR DESCRIPTION
## Summary
- add an interactive `scripts/bootstrap.sh` helper that prepares `.env`, aligns shared secrets, and records allowed chat IDs
- refresh the README quickstart, `.env.example`, and configuration/runbook docs to describe the streamlined Telegram setup
- add a `make migrate` target for docker-compose so the default schema can be applied with a single command

## Testing
- printf 'my-telegram-token\n\n12345\n\n\n' | ./scripts/bootstrap.sh

------
https://chatgpt.com/codex/tasks/task_e_68de2ac8fa0883339469fabd2c6e045c